### PR TITLE
Adjust Debian package regex match

### DIFF
--- a/deb-drop.go
+++ b/deb-drop.go
@@ -318,7 +318,7 @@ func validateRepos(lg *log.Logger, repoLocation string, repos []string) error {
 func validatePackageName(lg *log.Logger, name string, strict bool) error {
 	r := new(regexp.Regexp)
 	if strict {
-		r = regexp.MustCompile("^([-0-9A-Za-z.]+_){2}[-0-9A-Za-z]+.deb$")
+		r = regexp.MustCompile("^([-0-9A-Za-z.]+_)+[-0-9A-Za-z]+.deb$")
 	} else {
 		r = regexp.MustCompile("^([-0-9A-Za-z._]*)$")
 	}


### PR DESCRIPTION
Tough this is still not fully checking if it really matches the debian
conventions for package names having more than 2 version specifiers is
totally fine according to the standard.

See https://www.debian.org/doc/manuals/debian-reference/ch02.en.html#_debian_package_file_names