### PR TITLE
Remove temporary mutipart files after processing

### DIFF
--- a/deb-drop.go
+++ b/deb-drop.go
@@ -231,6 +231,9 @@ func mainHandler(w http.ResponseWriter, r *http.Request, config *Config, lg *log
 			return
 		}
 
+		// Remove the multipart-* files in /tmp
+		r.MultipartForm.RemoveAll()
+
 		err = removeOldPackages(lg, config, repos, packageName, keepVersions)
 		if err != nil {
 			w.WriteHeader(http.StatusInternalServerError)

--- a/deb-drop.go
+++ b/deb-drop.go
@@ -232,7 +232,7 @@ func mainHandler(w http.ResponseWriter, r *http.Request, config *Config, lg *log
 		}
 
 		// Remove the multipart-* files in /tmp
-		r.MultipartForm.RemoveAll()
+		defer r.MultipartForm.RemoveAll()
 
 		err = removeOldPackages(lg, config, repos, packageName, keepVersions)
 		if err != nil {


### PR DESCRIPTION
When deb-drop caches to disk (using multipart), it never cleans up these cache files.
Added the functionality to remove these cache files after processing.